### PR TITLE
Reliably set the quickfix title

### DIFF
--- a/plugin/qlist.vim
+++ b/plugin/qlist.vim
@@ -77,7 +77,11 @@ function! s:Qlist(command, selection, start_at_cursor, force, ...)
     execute min([ 10, len(getqflist()) ]) 'cwindow'
 
     " Add proper feedback to the statusline.
-    let w:quickfix_title = feedback
+    if has("patch-7.4.2200")
+        call setqflist([], 'r', {'title': feedback})
+    else
+        let w:quickfix_title = feedback
+    endif
 endfunction
 
 " Add the :Ilist command.


### PR DESCRIPTION
Right now w:quickfix_title is reset after closing the quickfix window.
As I see it, setting it doesn't associate it with the current quickfix list.
I don't know if such behavior should be classified as a bug in Vim.
For the time being, there is an easy fix for this.