### PR TITLE
Ignore the docs/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
Was showing as untracked content when cloned as a submodule in my `.vim` path