### PR TITLE
Add a [fname] to the doautocmd command

### DIFF
--- a/autoload/qlist.vim
+++ b/autoload/qlist.vim
@@ -69,7 +69,7 @@ function! qlist#Qlist(command, selection, start_at_cursor, force, ...)
 
     " Open the quickfix window if there is something to show.
     if exists("g:loaded_qf")
-        doautocmd QuickFixCmdPost
+        doautocmd QuickFixCmdPost cwindow
     else
         cclose
         execute min([ 10, len(getqflist()) ]) 'cwindow'


### PR DESCRIPTION
The pattern in QuickFixCmdPre and QuickFixCmdPost autocommands is
matched against the command being run. Since vim-qf uses l* and [^l]* to
distinguish between commands that perform on the quickfix and location
list, we need to add a [fname] to our "doautocmd {event} [fname]" call
as well. When [fname] is omitted, Vim uses the current file name which
will lead to an error for file names starting with an 'l', since vim-qlist always
populates the quickfix list and never the location list. Using 'cwindow' as
[fname] makes it more obvious what we're trying to trigger.